### PR TITLE
refactor: Consolidate types, create a Image component in ProductCard

### DIFF
--- a/src/components/product-card/components/product-card-image.tsx
+++ b/src/components/product-card/components/product-card-image.tsx
@@ -1,0 +1,27 @@
+import cn from 'clsx';
+import { ForwardedRef, forwardRef, ReactElement } from 'react';
+
+import type { ProductCardImageProps } from '../product-card.types';
+
+export const ProductCardImage = forwardRef((
+    props: ProductCardImageProps,
+    forwardedRef: ForwardedRef<HTMLImageElement> | null,
+  ): ReactElement => {
+    const {
+      className,
+      src,
+      alt,
+      ...rest
+    } = props;
+
+    return (
+      <img
+        {...rest}
+        src={src}
+        alt={alt}
+        className={cn('lui-product-card-image', className)}
+        ref={forwardedRef}
+      />
+    );
+  });
+  ProductCardImage.displayName = "ProductCard.Image";

--- a/src/components/product-card/components/product-card-price.tsx
+++ b/src/components/product-card/components/product-card-price.tsx
@@ -34,8 +34,8 @@ export const ProductCardPrice = forwardRef((
 
     return (
       <div {...rest} className={cn('lui-product-card-price', className)} ref={forwardedRef}>
-        {price ? <span className="lui-product-card-price-value--crossed">{formatPrice(price, _currency, _locale)}</span> : null}
-        {salePrice ? <span className="lui-product-card-price-value--sale">{formatPrice(salePrice, _currency, _locale)}</span> : null}
+        {price ? <span className="lui-product-card-price-value lui-product-card-price-value--crossed">{formatPrice(price, _currency, _locale)}</span> : null}
+        {salePrice ? <span className="lui-product-card-price-value lui-product-card-price-value--sale">{formatPrice(salePrice, _currency, _locale)}</span> : null}
       </div>
     );
   });

--- a/src/components/product-card/components/product-card-root.tsx
+++ b/src/components/product-card/components/product-card-root.tsx
@@ -14,7 +14,7 @@ import '../product-card.scss';
  *
  * <ProductCard.Root>
  *   <ProductCard.Header>
- *     <img src={product.image} alt={product.title} />
+ *     <ProductCard.Image src={product.image} alt={product.title} />
  *   </ProductCard.Header>
  *   <ProductCard.Body>
  *     <ProductCard.Title>{product.title}</ProductCard.Title>

--- a/src/components/product-card/index.ts
+++ b/src/components/product-card/index.ts
@@ -10,10 +10,12 @@ import { ProductCardBadge } from "./components/product-card-badge";
 import { ProductCardPrice } from "./components/product-card-price";
 import { ProductCardPriceRange } from "./components/product-card-price-range";
 import { ProductCardFavoriteButton } from "./components/product-card-favorite-button";
+import { ProductCardImage } from "./components/product-card-image";
 
 export const ProductCard = {
   Root: ProductCardRoot,
   Header: ProductCardHeader,
+  Image: ProductCardImage,
   Body: ProductCardBody,
   Footer: ProductCardFooter,
   Title: ProductCardTitle,
@@ -30,4 +32,5 @@ export type {
   ProductCardProps,
   ProductCardPriceProps,
   ProductCardPriceRangeProps,
+  ProductCardImageProps,
 } from "./product-card.types";

--- a/src/components/product-card/product-card.properties.scss
+++ b/src/components/product-card/product-card.properties.scss
@@ -39,7 +39,7 @@
 @property --lui-pc-box-shadow {
   syntax: "*";
   inherits: true;
-  initial-value: 0 4px 9px 0 #00284014, 0 17px 17px 0 #00284012, 0 38px 23px 0 #0028400a, 0 68px 27px 0 #00284003, 0 107px 30px 0 #00284000;
+  initial-value: none;
 };
 
 @property --lui-pc-favorite-btn-size {

--- a/src/components/product-card/product-card.scss
+++ b/src/components/product-card/product-card.scss
@@ -1,6 +1,8 @@
 @import url("./product-card.properties.scss");
 
 .lui-styled {
+  --lui-pc-box-shadow: var(--lui-base-shadow-1);
+
   .lui-product-card {
     display: flex;
     flex-direction: column;
@@ -15,7 +17,7 @@
     position: relative;
   }
 
-  .lui-product-card-header img {
+  .lui-product-card-image {
     width: 100%;
     display: block;
     border-radius: 6px 6px 0 0;
@@ -131,6 +133,7 @@
   .lui-product-card-price-value--crossed {
     text-decoration: line-through;
     opacity: 60%;
+    font-weight: 400;
   }
 
   .lui-product-card-price-value--sale {

--- a/src/components/product-card/product-card.stories.tsx
+++ b/src/components/product-card/product-card.stories.tsx
@@ -75,7 +75,7 @@ export const Basic: Story = {
             {...args}
           >
             <ProductCard.Header>
-              <img src={preview || product.image} alt={product.title} />
+              <ProductCard.Image src={preview || product.image} alt={product.title} />
             </ProductCard.Header>
             <ProductCard.Body>
               <SwatchBar.Root>
@@ -113,7 +113,7 @@ export const Simple: Story = {
             {...args}
           >
             <ProductCard.Header>
-              <img src={product.image} alt={product.title} />
+              <ProductCard.Image src={product.image} alt={product.title} />
             </ProductCard.Header>
             <ProductCard.Body>
               <ProductCard.Title>{product.title}</ProductCard.Title>
@@ -147,7 +147,7 @@ export const TextSwatches: Story = {
             {...args}
           >
             <ProductCard.Header>
-              <img src={preview || product.image} alt={product.title} />
+              <ProductCard.Image src={preview || product.image} alt={product.title} />
             </ProductCard.Header>
             <ProductCard.Body>
               <ProductCard.Label>{product.collection}</ProductCard.Label>
@@ -194,7 +194,7 @@ export const ColorSwatches: Story = {
             {...args}
           >
             <ProductCard.Header>
-              <img src={preview || product.image} alt={product.title} />
+              <ProductCard.Image src={preview || product.image} alt={product.title} />
             </ProductCard.Header>
             <ProductCard.Body>
               <ProductCard.Label>{product.collection}</ProductCard.Label>
@@ -241,7 +241,7 @@ export const ImageSwatches: Story = {
             {...args}
           >
             <ProductCard.Header>
-              <img src={preview || product.image} alt={product.title} />
+              <ProductCard.Image src={preview || product.image} alt={product.title} />
             </ProductCard.Header>
             <ProductCard.Body>
               <SwatchBar.Root>
@@ -280,7 +280,7 @@ export const BadgesAndFavoriteBtn: Story = {
             {...args}
           >
             <ProductCard.Header>
-              <img src={product.image} alt={product.title} />
+              <ProductCard.Image src={product.image} alt={product.title} />
               <ProductCard.FavoriteButton pressed={pressed} onClick={() => setPressed(!pressed)} />
             </ProductCard.Header>
             <ProductCard.Body>
@@ -321,7 +321,7 @@ export const RTL: Story = {
             {...args}
           >
             <ProductCard.Header>
-              <img src={preview || product.image} alt={product.title} />
+              <ProductCard.Image src={preview || product.image} alt={product.title} />
               <ProductCard.FavoriteButton pressed={pressed} onClick={() => setPressed(!pressed)} />
             </ProductCard.Header>
             <ProductCard.Body>
@@ -370,7 +370,7 @@ export const Themes: Story = {
               {...args}
             >
               <ProductCard.Header>
-                <img src={preview || product.image} alt={product.title} />
+                <ProductCard.Image src={preview || product.image} alt={product.title} />
               </ProductCard.Header>
               <ProductCard.Body>
                 <ProductCard.Badge>Limited Edition</ProductCard.Badge>
@@ -412,7 +412,7 @@ export const Themes: Story = {
               {...args}
             >
               <ProductCard.Header>
-                <img src={preview || product.image} alt={product.title} />
+                <ProductCard.Image src={preview || product.image} alt={product.title} />
               </ProductCard.Header>
               <ProductCard.Body>
                 <ProductCard.Badge>Limited Edition</ProductCard.Badge>
@@ -453,7 +453,7 @@ export const MixCustomHTML: Story = {
             {...args}
           >
             <ProductCard.Header>
-              <img src={product.image} alt={product.title} />
+              <ProductCard.Image src={product.image} alt={product.title} />
             </ProductCard.Header>
             <ProductCard.Body>
               <div style={{width: '100%', display: 'flex'}}>

--- a/src/components/product-card/product-card.types.ts
+++ b/src/components/product-card/product-card.types.ts
@@ -20,3 +20,8 @@ export interface ProductCardPriceRangeProps extends ProductCardProps {
   currency?: string,
   locale?: string,
 }
+
+export interface ProductCardImageProps extends Omit<ProductCardProps, 'children'> {
+  src: string,
+  alt: string,
+}

--- a/src/components/theme/index.ts
+++ b/src/components/theme/index.ts
@@ -3,5 +3,6 @@ export * from './theme.context';
 
 export type {
   ThemeContextProps,
+  ThemeProviderProps,
   ThemeProps,
 } from './theme.types'

--- a/src/components/theme/theme.context.tsx
+++ b/src/components/theme/theme.context.tsx
@@ -1,6 +1,6 @@
 import { createContext, PropsWithChildren, ReactElement, useContext } from 'react';
 import { DirectionProvider } from '@radix-ui/react-direction';
-import type { ThemeContextProps } from './theme.types';
+import type { ThemeContextProps, ThemeProviderProps } from './theme.types';
 
 const ThemeContext = createContext<ThemeContextProps>({});
 
@@ -8,7 +8,7 @@ export function useTheme(): ThemeContextProps {
   return useContext(ThemeContext);
 };
 
-export const ThemeProvider =  ({ children, value }: PropsWithChildren & { value: ThemeContextProps }): ReactElement => {
+export const ThemeProvider =  ({ children, value }: ThemeProviderProps): ReactElement => {
   const { dir='ltr' } = value;
   return (
     <ThemeContext.Provider value={value}>

--- a/src/components/theme/theme.properties.scss
+++ b/src/components/theme/theme.properties.scss
@@ -1,10 +1,10 @@
-@property --lui-font-family {
+@property --lui-base-font-family {
     syntax: "*";
     inherits: true;
     initial-value: Inter, Arial, Helvetica, sans-serif;
 };
 
-@property --lui-shadow-1 {
+@property --lui-base-shadow-1 {
     syntax: "*";
     inherits: true;
     initial-value: 0 4px 9px 0 #00284014, 0 17px 17px 0 #00284012, 0 38px 23px 0 #0028400a, 0 68px 27px 0 #00284003, 0 107px 30px 0 #00284000;

--- a/src/components/theme/theme.scss
+++ b/src/components/theme/theme.scss
@@ -1,7 +1,7 @@
 @import url("./theme.properties.scss");
 
 .lui-styled {
-    font-family: var(--lui-font-family);
+    font-family: var(--lui-base-font-family);
     -webkit-font-smoothing: antialiased;
 
     *,:after,:before {

--- a/src/components/theme/theme.stories.tsx
+++ b/src/components/theme/theme.stories.tsx
@@ -34,6 +34,7 @@ const product = {
   rating: 4.2,
   numRatings: 23,
   price: 25,
+  salePrice: 20,
   image: Shirt,
   href: 'https://bloomreach.com',
   variants: [{
@@ -75,7 +76,7 @@ export const Basic: Story = {
         <Theme {...args}>
           <ProductCard.Root>
             <ProductCard.Header>
-              <img src={preview || product.image} alt={product.title} />
+              <ProductCard.Image src={preview || product.image} alt={product.title} />
               <ProductCard.FavoriteButton pressed={pressed} onClick={() => setPressed(!pressed)} />
             </ProductCard.Header>
             <ProductCard.Body>
@@ -93,7 +94,7 @@ export const Basic: Story = {
               <ProductCard.SubTitle>{product.collection}</ProductCard.SubTitle>
             </ProductCard.Body>
             <ProductCard.Footer>
-            <ProductCard.Price price={product.price} salePrice={product.price - 10} />
+            <ProductCard.Price price={product.price} salePrice={product.salePrice} />
               <ProductCard.Button variant="primary">Add to cart</ProductCard.Button>
             </ProductCard.Footer>
           </ProductCard.Root>

--- a/src/components/theme/theme.types.ts
+++ b/src/components/theme/theme.types.ts
@@ -18,3 +18,7 @@ export interface ThemeContextProps {
 export interface ThemeProps extends PropsWithChildren, ThemeContextProps {
   className?: string,
 }
+
+export interface ThemeProviderProps extends PropsWithChildren {
+  value: ThemeContextProps,
+}


### PR DESCRIPTION
- Create a ProductCard.Image component to add a custom className and add styles instead of adding styles to the <img> tag
- Consolidate and export types for some of the Theme components
- Add a pattern to re-use css variables (box-shadow in the ProductCard component)
- Add a `base` prefix to base css variables, in case we want to be able to easily search for all base css variables